### PR TITLE
Add session-specific local file uploads

### DIFF
--- a/api/server/services/Files/process.js
+++ b/api/server/services/Files/process.js
@@ -409,6 +409,7 @@ const processFileUpload = async ({ req, res, metadata }) => {
     file,
     file_id,
     openai,
+    session_id: req.body.session_id,
   });
 
   if (isAssistantUpload && !metadata.message_file && !metadata.tool_resource) {
@@ -583,6 +584,7 @@ const processAgentFileUpload = async ({ req, res, metadata }) => {
     file_id,
     entity_id,
     basePath,
+    session_id: req.body.session_id,
   });
 
   let filepath = _filepath;


### PR DESCRIPTION
## Summary
- allow uploadLocalFile to accept optional `session_id`
- pass session_id from request body when handling uploads

## Testing
- `npm run test:api` *(fails: jest not found)*
- `npm run test:client` *(fails: cross-env not found)*