### PR TITLE
Add Minio storage strategy

### DIFF
--- a/api/server/controllers/agents/v1.js
+++ b/api/server/controllers/agents/v1.js
@@ -19,6 +19,7 @@ const {
 const { uploadImageBuffer, filterFile } = require('~/server/services/Files/process');
 const { getStrategyFunctions } = require('~/server/services/Files/strategies');
 const { refreshS3Url } = require('~/server/services/Files/S3/crud');
+const { refreshMinioUrl } = require('~/server/services/Files/Minio/crud');
 const { updateAction, getActions } = require('~/models/Action');
 const { updateAgentProjects } = require('~/models/Agent');
 const { getProjectByName } = require('~/models/Project');
@@ -107,6 +108,12 @@ const getAgentHandler = async (req, res) => {
     if (agent.avatar && agent.avatar?.source === FileSources.s3) {
       const originalUrl = agent.avatar.filepath;
       agent.avatar.filepath = await refreshS3Url(agent.avatar);
+      if (originalUrl !== agent.avatar.filepath) {
+        await updateAgent({ id }, { avatar: agent.avatar });
+      }
+    } else if (agent.avatar && agent.avatar?.source === FileSources.minio) {
+      const originalUrl = agent.avatar.filepath;
+      agent.avatar.filepath = await refreshMinioUrl(agent.avatar);
       if (originalUrl !== agent.avatar.filepath) {
         await updateAgent({ id }, { avatar: agent.avatar });
       }

--- a/api/server/services/AppService.js
+++ b/api/server/services/AppService.js
@@ -16,6 +16,7 @@ const { loadTurnstileConfig } = require('./start/turnstile');
 const { azureConfigSetup } = require('./start/azureOpenAI');
 const { processModelSpecs } = require('./start/modelSpecs');
 const { initializeS3 } = require('./Files/S3/initialize');
+const { initializeMinio } = require('./Files/Minio/initialize');
 const { loadAndFormatTools } = require('./ToolService');
 const { agentsConfigSetup } = require('./start/agents');
 const { initializeRoles } = require('~/models/Role');
@@ -56,6 +57,8 @@ const AppService = async (app) => {
     initializeAzureBlobService();
   } else if (fileStrategy === FileSources.s3) {
     initializeS3();
+  } else if (fileStrategy === FileSources.minio) {
+    initializeMinio();
   }
 
   /** @type {Record<string, FunctionTool>} */

--- a/api/server/services/Files/Minio/crud.js
+++ b/api/server/services/Files/Minio/crud.js
@@ -1,0 +1,469 @@
+const fs = require('fs');
+const path = require('path');
+const fetch = require('node-fetch');
+const { FileSources } = require('librechat-data-provider');
+const {
+  PutObjectCommand,
+  GetObjectCommand,
+  HeadObjectCommand,
+  DeleteObjectCommand,
+} = require('@aws-sdk/client-client');
+const { getSignedUrl } = require('@aws-sdk/client-request-presigner');
+const { initializeMinio } = require('./initialize');
+const { logger } = require('~/config');
+
+const bucketName = process.env.MINIO_BUCKET_NAME || 'q-hub';
+const defaultBasePath = 'images';
+
+let minioUrlExpirySeconds = 7 * 24 * 60 * 60;
+let minioRefreshExpiryMs = null;
+
+if (process.env.MINIO_URL_EXPIRY_SECONDS !== undefined) {
+  const parsed = parseInt(process.env.MINIO_URL_EXPIRY_SECONDS, 10);
+
+  if (!isNaN(parsed) && parsed > 0) {
+    minioUrlExpirySeconds = Math.min(parsed, 7 * 24 * 60 * 60);
+  } else {
+    logger.warn(
+      `[Minio] Invalid MINIO_URL_EXPIRY_SECONDS value: "${process.env.MINIO_URL_EXPIRY_SECONDS}". Using 7-day expiry.`,
+    );
+  }
+}
+
+if (process.env.MINIO_REFRESH_EXPIRY_MS !== null && process.env.MINIO_REFRESH_EXPIRY_MS) {
+  const parsed = parseInt(process.env.MINIO_REFRESH_EXPIRY_MS, 10);
+
+  if (!isNaN(parsed) && parsed > 0) {
+    minioRefreshExpiryMs = parsed;
+    logger.info(`[Minio] Using custom refresh expiry time: ${minioRefreshExpiryMs}ms`);
+  } else {
+    logger.warn(
+      `[Minio] Invalid MINIO_REFRESH_EXPIRY_MS value: "${process.env.MINIO_REFRESH_EXPIRY_MS}". Using default refresh logic.`,
+    );
+  }
+}
+
+/**
+ * Constructs the Minio key based on the base path, user ID, and file name.
+ */
+const getMinioKey = (basePath, userId, fileName) => `${basePath}/${userId}/${fileName}`;
+
+/**
+ * Uploads a buffer to Minio and returns a signed URL.
+ *
+ * @param {Object} params
+ * @param {string} params.userId - The user's unique identifier.
+ * @param {Buffer} params.buffer - The buffer containing file data.
+ * @param {string} params.fileName - The file name to use in Minio.
+ * @param {string} [params.basePath='images'] - The base path in the bucket.
+ * @returns {Promise<string>} Signed URL of the uploaded file.
+ */
+async function saveBufferToMinio({ userId, buffer, fileName, basePath = defaultBasePath }) {
+  const key = getMinioKey(basePath, userId, fileName);
+  const params = { Bucket: bucketName, Key: key, Body: buffer };
+
+  try {
+    const client = initializeMinio();
+    await client.send(new PutObjectCommand(params));
+    return await getMinioURL({ userId, fileName, basePath, bucket: bucketName });
+  } catch (error) {
+    logger.error('[saveBufferToMinio] Error uploading buffer to Minio:', error.message);
+    throw error;
+  }
+}
+
+/**
+ * Retrieves a URL for a file stored in Minio.
+ * Returns a signed URL with expiration time or a proxy URL based on config
+ *
+ * @param {Object} params
+ * @param {string} params.userId - The user's unique identifier.
+ * @param {string} params.fileName - The file name in Minio.
+ * @param {string} [params.basePath='images'] - The base path in the bucket.
+ * @returns {Promise<string>} A URL to access the Minio object
+ */
+async function getMinioURL({ userId, fileName, bucket = bucketName, basePath = defaultBasePath }) {
+  const key = getMinioKey(basePath, userId, fileName);
+  const params = { Bucket: bucket, Key: key };
+
+  try {
+    const client = initializeMinio();
+    return await getSignedUrl(client, new GetObjectCommand(params), { expiresIn: minioUrlExpirySeconds });
+  } catch (error) {
+    logger.error('[getMinioURL] Error getting signed URL from Minio:', error.message);
+    throw error;
+  }
+}
+
+/**
+ * Saves a file from a given URL to Minio.
+ *
+ * @param {Object} params
+ * @param {string} params.userId - The user's unique identifier.
+ * @param {string} params.URL - The source URL of the file.
+ * @param {string} params.fileName - The file name to use in Minio.
+ * @param {string} [params.basePath='images'] - The base path in the bucket.
+ * @returns {Promise<string>} Signed URL of the uploaded file.
+ */
+async function saveURLToMinio({ userId, URL, fileName, basePath = defaultBasePath }) {
+  try {
+    const response = await fetch(URL);
+    const buffer = await response.buffer();
+    // Optionally you can call getBufferMetadata(buffer) if needed.
+    return await saveBufferToMinio({ userId, buffer, fileName, basePath });
+  } catch (error) {
+    logger.error('[saveURLToMinio] Error uploading file from URL to Minio:', error.message);
+    throw error;
+  }
+}
+
+/**
+ * Deletes a file from Minio.
+ *
+ * @param {Object} params
+ * @param {ServerRequest} params.req
+ * @param {MongoFile} params.file - The file object to delete.
+ * @returns {Promise<void>}
+ */
+async function deleteFileFromMinio(req, file) {
+  const key = extractKeyFromMinioUrl(file.filepath);
+  const params = { Bucket: bucketName, Key: key };
+  if (!key.includes(req.user.id)) {
+    const message = `[deleteFileFromMinio] User ID mismatch: ${req.user.id} vs ${key}`;
+    logger.error(message);
+    throw new Error(message);
+  }
+
+  try {
+    const client = initializeMinio();
+
+    try {
+      const headCommand = new HeadObjectCommand(params);
+      await client.send(headCommand);
+      logger.debug('[deleteFileFromMinio] File exists, proceeding with deletion');
+    } catch (headErr) {
+      if (headErr.name === 'NotFound') {
+        logger.warn(`[deleteFileFromMinio] File does not exist: ${key}`);
+        return;
+      }
+    }
+
+    const deleteResult = await client.send(new DeleteObjectCommand(params));
+    logger.debug('[deleteFileFromMinio] Delete command response:', JSON.stringify(deleteResult));
+    try {
+      await client.send(new HeadObjectCommand(params));
+      logger.error('[deleteFileFromMinio] File still exists after deletion!');
+    } catch (verifyErr) {
+      if (verifyErr.name === 'NotFound') {
+        logger.debug(`[deleteFileFromMinio] Verified file is deleted: ${key}`);
+      } else {
+        logger.error('[deleteFileFromMinio] Error verifying deletion:', verifyErr);
+      }
+    }
+
+    logger.debug('[deleteFileFromMinio] Minio File deletion completed');
+  } catch (error) {
+    logger.error(`[deleteFileFromMinio] Error deleting file from Minio: ${error.message}`);
+    logger.error(error.stack);
+
+    // If the file is not found, we can safely return.
+    if (error.code === 'NoSuchKey') {
+      return;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Uploads a local file to Minio by streaming it directly without loading into memory.
+ *
+ * @param {Object} params
+ * @param {import('express').Request} params.req - The Express request (must include user).
+ * @param {Express.Multer.File} params.file - The file object from Multer.
+ * @param {string} params.file_id - Unique file identifier.
+ * @param {string} [params.basePath='images'] - The base path in the bucket.
+ * @returns {Promise<{ filepath: string, bytes: number }>}
+ */
+async function uploadFileToMinio({ req, file, file_id, bucket = bucketName, basePath = defaultBasePath }) {
+  try {
+    const inputFilePath = file.path;
+    const userId = req.user.id;
+    const fileName = `${file_id}__${path.basename(inputFilePath)}`;
+    const key = getMinioKey(basePath, userId, fileName);
+
+    const stats = await fs.promises.stat(inputFilePath);
+    const bytes = stats.size;
+    const fileStream = fs.createReadStream(inputFilePath);
+
+    const client = initializeMinio();
+    const uploadParams = {
+      Bucket: bucket,
+      Key: key,
+      Body: fileStream,
+    };
+
+    await client.send(new PutObjectCommand(uploadParams));
+    const fileURL = await getMinioURL({ userId, fileName, basePath, bucket });
+    return { filepath: fileURL, bytes };
+  } catch (error) {
+    logger.error('[uploadFileToMinio] Error streaming file to Minio:', error);
+    try {
+      if (file && file.path) {
+        await fs.promises.unlink(file.path);
+      }
+    } catch (unlinkError) {
+      logger.error(
+        '[uploadFileToMinio] Error deleting temporary file, likely already deleted:',
+        unlinkError.message,
+      );
+    }
+    throw error;
+  }
+}
+
+/**
+ * Extracts the Minio key from a URL or returns the key if already properly formatted
+ *
+ * @param {string} fileUrlOrKey - The file URL or key
+ * @returns {string} The Minio key
+ */
+function extractKeyFromMinioUrl(fileUrlOrKey) {
+  if (!fileUrlOrKey) {
+    throw new Error('Invalid input: URL or key is empty');
+  }
+
+  try {
+    const url = new URL(fileUrlOrKey);
+    return url.pathname.substring(1);
+  } catch (error) {
+    const parts = fileUrlOrKey.split('/');
+
+    if (parts.length >= 3 && !fileUrlOrKey.startsWith('http') && !fileUrlOrKey.startsWith('/')) {
+      return fileUrlOrKey;
+    }
+
+    return fileUrlOrKey.startsWith('/') ? fileUrlOrKey.substring(1) : fileUrlOrKey;
+  }
+}
+
+/**
+ * Retrieves a readable stream for a file stored in Minio.
+ *
+ * @param {ServerRequest} req - Server request object.
+ * @param {string} filePath - The Minio key of the file.
+ * @returns {Promise<NodeJS.ReadableStream>}
+ */
+async function getMinioFileStream(_req, filePath) {
+  try {
+    const Key = extractKeyFromMinioUrl(filePath);
+    const params = { Bucket: bucketName, Key };
+    const client = initializeMinio();
+    const data = await client.send(new GetObjectCommand(params));
+    return data.Body; // Returns a Node.js ReadableStream.
+  } catch (error) {
+    logger.error('[getMinioFileStream] Error retrieving Minio file stream:', error);
+    throw error;
+  }
+}
+
+/**
+ * Determines if a signed Minio URL is close to expiration
+ *
+ * @param {string} signedUrl - The signed Minio URL
+ * @param {number} bufferSeconds - Buffer time in seconds
+ * @returns {boolean} True if the URL needs refreshing
+ */
+function needsRefresh(signedUrl, bufferSeconds) {
+  try {
+    // Parse the URL
+    const url = new URL(signedUrl);
+
+    // Check if it has the signature parameters that indicate it's a signed URL
+    // X-Amz-Signature is the most reliable indicator for AWS signed URLs
+    if (!url.searchParams.has('X-Amz-Signature')) {
+      // Not a signed URL, so no expiration to check (or it's already a proxy URL)
+      return false;
+    }
+
+    // Extract the expiration time from the URL
+    const expiresParam = url.searchParams.get('X-Amz-Expires');
+    const dateParam = url.searchParams.get('X-Amz-Date');
+
+    if (!expiresParam || !dateParam) {
+      // Missing expiration information, assume it needs refresh to be safe
+      return true;
+    }
+
+    // Parse the AWS date format (YYYYMMDDTHHMMSSZ)
+    const year = dateParam.substring(0, 4);
+    const month = dateParam.substring(4, 6);
+    const day = dateParam.substring(6, 8);
+    const hour = dateParam.substring(9, 11);
+    const minute = dateParam.substring(11, 13);
+    const second = dateParam.substring(13, 15);
+
+    const dateObj = new Date(`${year}-${month}-${day}T${hour}:${minute}:${second}Z`);
+    const expiresAtDate = new Date(dateObj.getTime() + parseInt(expiresParam) * 1000);
+
+    // Check if it's close to expiration
+    const now = new Date();
+
+    // If MINIO_REFRESH_EXPIRY_MS is set, use it to determine if URL is expired
+    if (minioRefreshExpiryMs !== null) {
+      const urlCreationTime = dateObj.getTime();
+      const urlAge = now.getTime() - urlCreationTime;
+      return urlAge >= minioRefreshExpiryMs;
+    }
+
+    // Otherwise use the default buffer-based logic
+    const bufferTime = new Date(now.getTime() + bufferSeconds * 1000);
+    return expiresAtDate <= bufferTime;
+  } catch (error) {
+    logger.error('Error checking URL expiration:', error);
+    // If we can't determine, assume it needs refresh to be safe
+    return true;
+  }
+}
+
+/**
+ * Generates a new URL for an expired Minio URL
+ * @param {string} currentURL - The current file URL
+ * @returns {Promise<string | undefined>}
+ */
+async function getNewMinioURL(currentURL) {
+  try {
+    const minioKey = extractKeyFromMinioUrl(currentURL);
+    if (!minioKey) {
+      return;
+    }
+    const keyParts = minioKey.split('/');
+    if (keyParts.length < 3) {
+      return;
+    }
+
+    const basePath = keyParts[0];
+    const userId = keyParts[1];
+    const fileName = keyParts.slice(2).join('/');
+
+    return await getMinioURL({
+      userId,
+      fileName,
+      basePath,
+      bucket: bucketName,
+    });
+  } catch (error) {
+    logger.error('Error getting new Minio URL:', error);
+  }
+}
+
+/**
+ * Refreshes Minio URLs for an array of files if they're expired or close to expiring
+ *
+ * @param {MongoFile[]} files - Array of file documents
+ * @param {(files: MongoFile[]) => Promise<void>} batchUpdateFiles - Function to update files in the database
+ * @param {number} [bufferSeconds=3600] - Buffer time in seconds to check for expiration
+ * @returns {Promise<MongoFile[]>} The files with refreshed URLs if needed
+ */
+async function refreshMinioFileUrls(files, batchUpdateFiles, bufferSeconds = 3600) {
+  if (!files || !Array.isArray(files) || files.length === 0) {
+    return files;
+  }
+
+  const filesToUpdate = [];
+
+  for (let i = 0; i < files.length; i++) {
+    const file = files[i];
+    if (!file?.file_id) {
+      continue;
+    }
+    if (file.source !== FileSources.client) {
+      continue;
+    }
+    if (!file.filepath) {
+      continue;
+    }
+    if (!needsRefresh(file.filepath, bufferSeconds)) {
+      continue;
+    }
+    try {
+      const newURL = await getNewMinioURL(file.filepath);
+      if (!newURL) {
+        continue;
+      }
+      filesToUpdate.push({
+        file_id: file.file_id,
+        filepath: newURL,
+      });
+      files[i].filepath = newURL;
+    } catch (error) {
+      logger.error(`Error refreshing Minio URL for file ${file.file_id}:`, error);
+    }
+  }
+
+  if (filesToUpdate.length > 0) {
+    await batchUpdateFiles(filesToUpdate);
+  }
+
+  return files;
+}
+
+/**
+ * Refreshes a single Minio URL if it's expired or close to expiring
+ *
+ * @param {{ filepath: string, source: string }} fileObj - Simple file object containing filepath and source
+ * @param {number} [bufferSeconds=3600] - Buffer time in seconds to check for expiration
+ * @returns {Promise<string>} The refreshed URL or the original URL if no refresh needed
+ */
+async function refreshMinioUrl(fileObj, bufferSeconds = 3600) {
+  if (!fileObj || fileObj.source !== FileSources.client || !fileObj.filepath) {
+    return fileObj?.filepath || '';
+  }
+
+  if (!needsRefresh(fileObj.filepath, bufferSeconds)) {
+    return fileObj.filepath;
+  }
+
+  try {
+    const minioKey = extractKeyFromMinioUrl(fileObj.filepath);
+    if (!minioKey) {
+      logger.warn(`Unable to extract Minio key from URL: ${fileObj.filepath}`);
+      return fileObj.filepath;
+    }
+
+    const keyParts = minioKey.split('/');
+    if (keyParts.length < 3) {
+      logger.warn(`Invalid Minio key format: ${minioKey}`);
+      return fileObj.filepath;
+    }
+
+    const basePath = keyParts[0];
+    const userId = keyParts[1];
+    const fileName = keyParts.slice(2).join('/');
+
+    const newUrl = await getMinioURL({
+      userId,
+      fileName,
+      basePath,
+      bucket: bucketName,
+    });
+
+    logger.debug(`Refreshed Minio URL for key: ${minioKey}`);
+    return newUrl;
+  } catch (error) {
+    logger.error(`Error refreshing Minio URL: ${error.message}`);
+    return fileObj.filepath;
+  }
+}
+
+module.exports = {
+  saveBufferToMinio,
+  saveURLToMinio,
+  getMinioURL,
+  deleteFileFromMinio,
+  uploadFileToMinio,
+  getMinioFileStream,
+  refreshMinioFileUrls,
+  refreshMinioUrl,
+  needsRefresh,
+  getNewMinioURL,
+};

--- a/api/server/services/Files/Minio/images.js
+++ b/api/server/services/Files/Minio/images.js
@@ -1,0 +1,118 @@
+const fs = require('fs');
+const path = require('path');
+const sharp = require('sharp');
+const { resizeImageBuffer } = require('../images/resize');
+const { updateUser } = require('~/models/userMethods');
+const { saveBufferToMinio } = require('./crud');
+const { updateFile } = require('~/models/File');
+const { logger } = require('~/config');
+
+const defaultBasePath = 'images';
+
+/**
+ * Resizes, converts, and uploads an image file to Minio.
+ *
+ * @param {Object} params
+ * @param {import('express').Request} params.req - Express request (expects user and app.locals.imageOutputType).
+ * @param {Express.Multer.File} params.file - File object from Multer.
+ * @param {string} params.file_id - Unique file identifier.
+ * @param {any} params.endpoint - Endpoint identifier used in image processing.
+ * @param {string} [params.resolution='high'] - Desired image resolution.
+ * @param {string} [params.basePath='images'] - Base path in the bucket.
+ * @returns {Promise<{ filepath: string, bytes: number, width: number, height: number }>}
+ */
+async function uploadImageToMinio({
+  req,
+  file,
+  file_id,
+  endpoint,
+  resolution = 'high',
+  basePath = defaultBasePath,
+}) {
+  try {
+    const inputFilePath = file.path;
+    const inputBuffer = await fs.promises.readFile(inputFilePath);
+    const {
+      buffer: resizedBuffer,
+      width,
+      height,
+    } = await resizeImageBuffer(inputBuffer, resolution, endpoint);
+    const extension = path.extname(inputFilePath);
+    const userId = req.user.id;
+
+    let processedBuffer;
+    let fileName = `${file_id}__${path.basename(inputFilePath)}`;
+    const targetExtension = `.${req.app.locals.imageOutputType}`;
+
+    if (extension.toLowerCase() === targetExtension) {
+      processedBuffer = resizedBuffer;
+    } else {
+      processedBuffer = await sharp(resizedBuffer)
+        .toFormat(req.app.locals.imageOutputType)
+        .toBuffer();
+      fileName = fileName.replace(new RegExp(path.extname(fileName) + '$'), targetExtension);
+      if (!path.extname(fileName)) {
+        fileName += targetExtension;
+      }
+    }
+
+    const downloadURL = await saveBufferToMinio({
+      userId,
+      buffer: processedBuffer,
+      fileName,
+      basePath,
+    });
+    await fs.promises.unlink(inputFilePath);
+    const bytes = Buffer.byteLength(processedBuffer);
+    return { filepath: downloadURL, bytes, width, height };
+  } catch (error) {
+    logger.error('[uploadImageToMinio] Error uploading image to Minio:', error.message);
+    throw error;
+  }
+}
+
+/**
+ * Updates a file record and returns its signed URL.
+ *
+ * @param {import('express').Request} req - Express request.
+ * @param {Object} file - File metadata.
+ * @returns {Promise<[Promise<any>, string]>}
+ */
+async function prepareImageURLMinio(req, file) {
+  try {
+    const updatePromise = updateFile({ file_id: file.file_id });
+    return Promise.all([updatePromise, file.filepath]);
+  } catch (error) {
+    logger.error('[prepareImageURLMinio] Error preparing image URL:', error.message);
+    throw error;
+  }
+}
+
+/**
+ * Processes a user's avatar image by uploading it to Minio and updating the user's avatar URL if required.
+ *
+ * @param {Object} params
+ * @param {Buffer} params.buffer - Avatar image buffer.
+ * @param {string} params.userId - User's unique identifier.
+ * @param {string} params.manual - 'true' or 'false' flag for manual update.
+ * @param {string} [params.basePath='images'] - Base path in the bucket.
+ * @returns {Promise<string>} Signed URL of the uploaded avatar.
+ */
+async function processMinioAvatar({ buffer, userId, manual, basePath = defaultBasePath }) {
+  try {
+    const downloadURL = await saveBufferToMinio({ userId, buffer, fileName: 'avatar.png', basePath });
+    if (manual === 'true') {
+      await updateUser(userId, { avatar: downloadURL });
+    }
+    return downloadURL;
+  } catch (error) {
+    logger.error('[processMinioAvatar] Error processing Minio avatar:', error.message);
+    throw error;
+  }
+}
+
+module.exports = {
+  uploadImageToMinio,
+  prepareImageURLMinio,
+  processMinioAvatar,
+};

--- a/api/server/services/Files/Minio/index.js
+++ b/api/server/services/Files/Minio/index.js
@@ -1,0 +1,9 @@
+const crud = require('./crud');
+const images = require('./images');
+const initialize = require('./initialize');
+
+module.exports = {
+  ...crud,
+  ...images,
+  ...initialize,
+};

--- a/api/server/services/Files/Minio/initialize.js
+++ b/api/server/services/Files/Minio/initialize.js
@@ -1,0 +1,51 @@
+const { S3Client } = require('@aws-sdk/client-s3');
+const { logger } = require('~/config');
+
+let minio = null;
+
+/**
+ * Initializes and returns an instance of the AWS S3 client.
+ *
+ * If AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are provided, they will be used.
+ * Otherwise, the AWS SDK's default credentials chain (including IRSA) is used.
+ *
+ * If AWS_ENDPOINT_URL is provided, it will be used as the endpoint.
+ *
+ * @returns {S3Client|null} An instance of S3Client if the region is provided; otherwise, null.
+ */
+const initializeMinio = () => {
+  if (minio) {
+    return minio;
+  }
+
+  const region = process.env.MINIO_REGION;
+  const endpoint = process.env.MINIO_ENDPOINT;
+  if (!region || !endpoint) {
+    logger.error('[initializeMinio] MINIO_REGION or MINIO_ENDPOINT not set.');
+    return null;
+  }
+
+  const accessKeyId = process.env.MINIO_ACCESS_KEY;
+  const secretAccessKey = process.env.MINIO_SECRET_KEY;
+
+  const config = {
+    region,
+    endpoint,
+    forcePathStyle: true,
+  };
+
+  if (accessKeyId && secretAccessKey) {
+    minio = new S3Client({
+      ...config,
+      credentials: { accessKeyId, secretAccessKey },
+    });
+    logger.info('[initializeMinio] client initialized with provided credentials.');
+  } else {
+    minio = new S3Client(config);
+    logger.info('[initializeMinio] client initialized without credentials.');
+  }
+
+  return minio;
+};
+
+module.exports = { initializeMinio };

--- a/api/server/services/Files/images/encode.js
+++ b/api/server/services/Files/images/encode.js
@@ -78,7 +78,7 @@ const base64Only = new Set([
   EModelEndpoint.bedrock,
 ]);
 
-const blobStorageSources = new Set([FileSources.azure_blob, FileSources.s3]);
+const blobStorageSources = new Set([FileSources.azure_blob, FileSources.s3, FileSources.minio]);
 
 /**
  * Encodes and formats the given files.

--- a/api/server/services/Files/strategies.js
+++ b/api/server/services/Files/strategies.js
@@ -33,6 +33,17 @@ const {
   uploadFileToS3,
 } = require('./S3');
 const {
+  getMinioURL,
+  saveURLToMinio,
+  saveBufferToMinio,
+  getMinioFileStream,
+  uploadImageToMinio,
+  prepareImageURLMinio,
+  deleteFileFromMinio,
+  processMinioAvatar,
+  uploadFileToMinio,
+} = require('./Minio');
+const {
   saveBufferToAzure,
   saveURLToAzure,
   getAzureURL,
@@ -94,6 +105,22 @@ const s3Strategy = () => ({
   processAvatar: processS3Avatar,
   handleImageUpload: uploadImageToS3,
   getDownloadStream: getS3FileStream,
+});
+
+/**
+ * Minio Storage Strategy Functions
+ *
+ * */
+const minioStrategy = () => ({
+  handleFileUpload: uploadFileToMinio,
+  saveURL: saveURLToMinio,
+  getFileURL: getMinioURL,
+  deleteFile: deleteFileFromMinio,
+  saveBuffer: saveBufferToMinio,
+  prepareImagePayload: prepareImageURLMinio,
+  processAvatar: processMinioAvatar,
+  handleImageUpload: uploadImageToMinio,
+  getDownloadStream: getMinioFileStream,
 });
 
 /**
@@ -218,6 +245,8 @@ const getStrategyFunctions = (fileSource) => {
     return vectorStrategy();
   } else if (fileSource === FileSources.s3) {
     return s3Strategy();
+  } else if (fileSource === FileSources.minio) {
+    return minioStrategy();
   } else if (fileSource === FileSources.execute_code) {
     return codeOutputStrategy();
   } else if (fileSource === FileSources.mistral_ocr) {

--- a/packages/data-provider/src/types/files.ts
+++ b/packages/data-provider/src/types/files.ts
@@ -7,6 +7,7 @@ export enum FileSources {
   azure_blob = 'azure_blob',
   openai = 'openai',
   s3 = 's3',
+  minio = 'minio',
   vectordb = 'vectordb',
   execute_code = 'execute_code',
   mistral_ocr = 'mistral_ocr',


### PR DESCRIPTION
## Summary
- support Minio as a new file strategy
- implement Minio CRUD helpers and initialization
- upload files to Minio when session ID provided
- refresh Minio URLs and integrate with user and agent controllers
- revert previous S3 changes

## Testing
- `npm run test:api` *(fails: jest not found)*